### PR TITLE
Add content for module 2

### DIFF
--- a/03-materials/02-anatomy-of-extensions.md
+++ b/03-materials/02-anatomy-of-extensions.md
@@ -99,3 +99,9 @@ graph TB
     ```bash
     jupyter lab
     ```
+
+5. Confirm the extension was loaded. Open your browser's dev console (F12 or
+   `CTRL+SHIFT+I`) and look for log messages reading:
+
+   * `JupyterLab extension myextension is activated`
+   * `This is /myextension/get-example endpoint!`


### PR DESCRIPTION
Contains some stuff that maybe we originally thought would be in module 5?

I'm thinking if we include mini exercises in module 2 & 4, like initializing from a template, users will arrive at module 5 ready to hit the ground running, instead of having to pause and start doing some setup. It's a bit more hands-on than the previous workshops.

@RRosio what do you think?

<!-- readthedocs-preview jupytercon2025-developingextensions start -->
---
:mag: Preview: https://jupytercon2025-developingextensions--17.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview jupytercon2025-developingextensions end -->