### PR TITLE
Upgrade to MyST 1.6.3 and remove workaround for RTD build failures

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -13,10 +13,7 @@ project:
 
 
 site:
-  # Temporarily hash-pin the theme.
-  # See: https://github.com/jupytercon/jupytercon2025-developingextensions/issues/6
-  template: "https://github.com/myst-templates/book-theme/archive/de4c1e9c09c6cd12fc529c1f22e8abf8e7f35381.zip"
-  # template: "book-theme"
+  template: "book-theme"
   actions:
     - title: "View source"
       url: "https://github.com/jupytercon/jupytercon2025-developingextensions"

--- a/pixi.lock
+++ b/pixi.lock
@@ -24,7 +24,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.1-he9a06e4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mystmd-1.6.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mystmd-1.6.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-24.4.1-heeeca48_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.3-h26f9b46_0.conda
@@ -228,17 +228,17 @@ packages:
   license_family: Other
   size: 60963
   timestamp: 1727963148474
-- conda: https://conda.anaconda.org/conda-forge/noarch/mystmd-1.6.1-pyhcf101f3_0.conda
-  sha256: 28f41083766af4396ff1e2ebec47c1bb4dd41ec122df65e6c7f61fbb19be0111
-  md5: 9ca738c2c6254f6a74d6df3eadb6064c
+- conda: https://conda.anaconda.org/conda-forge/noarch/mystmd-1.6.3-pyhcf101f3_0.conda
+  sha256: 8966f94714340a55f55caf5efee7a35cc37a6071f5d3ca24fca4aca330c433a8
+  md5: ae4b2d18b3defadb3192d604efaec2e7
   depends:
   - python >=3.10
   - nodejs >=18
   - python
   license: MIT
   license_family: MIT
-  size: 2164590
-  timestamp: 1757360530219
+  size: 2164006
+  timestamp: 1760141962040
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
   sha256: 3fde293232fa3fca98635e1167de6b7c7fda83caf24b9d6c91ec9eefb4f4d586
   md5: 47e340acb35de30501a76c7c799c41d7

--- a/pixi.toml
+++ b/pixi.toml
@@ -10,4 +10,4 @@ render = "myst build --strict --html"
 preview = "myst start"
 
 [dependencies]
-mystmd = ">=1.6.1,<2"
+mystmd = ">=1.6.3,<2"


### PR DESCRIPTION


<!-- readthedocs-preview jupytercon2025-developingextensions start -->
---
:mag: Preview: https://jupytercon2025-developingextensions--24.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview jupytercon2025-developingextensions end -->