### PR TITLE
Add workshop description to index page

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,3 +6,29 @@
 These materials are under development and subject to change all the way until
 JupyterCon!
 :::
+
+JupyterLab extensions are the key to customizing, enhancing, and scaling the
+Jupyter experience, whether you’re integrating domain-specific tools, adding new
+UI components or bridging frontend and backend workflows.
+
+**In this hands-on workshop, we’ll walk through the complete lifecycle of building
+a JupyterLab extension, from scaffolding and plugin architecture to packaging
+and publishing.**
+
+Participants will be exposed to basic and advanced extension development
+concepts: creating custom UI components, managing state and data, interfacing
+with other frontend and server extensions, and publishing extensions on PyPI.
+You’ll come away with the building blocks needed to begin your journey in
+developing extensions.
+
+Together, we will create a basic extension from scratch, overview the landscape
+of extensions, explore advanced extensions (for example, JupyterGIS, providing
+real-time collaborative geospatial analysis in JupyterLab), and work on our own
+new extensions or contribute to existing extensions.
+After lunch we'll show you how to use AI to rapidly prototype, iterate on
+complex features and ship production-ready extensions that solve real user
+problems.
+
+By the end, you'll have created multiple working extensions and the
+knowledge to bring your own ideas to life, contributing to the vibrant Jupyter
+ecosystem.


### PR DESCRIPTION


<!-- readthedocs-preview jupytercon2025-developingextensions start -->
---
:mag: Preview: https://jupytercon2025-developingextensions--26.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview jupytercon2025-developingextensions end -->