### PR TITLE
Add definitions of frontend and server extensions

### DIFF
--- a/03-vocabulary.md
+++ b/03-vocabulary.md
@@ -20,8 +20,8 @@ running on, for example to read files from disk.
 [See the official docs for more!](https://jupyter-server.readthedocs.io/en/stable/developers/extensions.html)
 
 Frontend extension
-: An extension which adds functionality that executes solely in the browser and interact
-with existing JupyterLab frontend components.
+: An extension which modifies the user interface and/or adds functionality that executes
+solely in the browser, and interacts with existing JupyterLab frontend components.
 This includes themes, UI elements, viewers, code editors, and more.
 They are built with [Lumino](https://lumino.readthedocs.io/en/latest/) and/or
 [React](https://react.dev/learn) components.


### PR DESCRIPTION
This is a really rough pass. Edits _very_ welcome :)

<!-- readthedocs-preview jupytercon2025-developingextensions start -->
---
:mag: Preview: https://jupytercon2025-developingextensions--41.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview jupytercon2025-developingextensions end -->