### PR TITLE
Remove learning objectives from anatomy module

### DIFF
--- a/04-materials/02-anatomy-of-extensions.md
+++ b/04-materials/02-anatomy-of-extensions.md
@@ -1,12 +1,5 @@
 # 🧬 2 - Anatomy of an extension
 
-:::{hint} Learning objectives
-* Understand the difference between extensions, plugins, and widgets
-* Understand how to get started with writing an extension
-* Understand how to structure and navigate an extension project
-* Practice and get comfortable with the development & testing loop
-:::
-
 :::{important} Outcomes
 In this module, we will:
 


### PR DESCRIPTION
I'm not sure if I think this is the correct course of action, but it's based on the Diataxis tutorial-writing principles.

>"In this tutorial you will learn…" [...] is presumptuous and a very poor pattern.

<https://diataxis.fr/tutorials/#show-the-learner-where-they-ll-be-going>

While we're not saying "you will learn", we are stating **objectives**... but perhaps still makes sense to remove this. Alongside the outcomes section, it's perhaps noisy?

<!-- readthedocs-preview jupytercon2025-developingextensions start -->
---
:mag: Preview: https://jupytercon2025-developingextensions--54.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview jupytercon2025-developingextensions end -->