### PR TITLE
Remove Martha from instructors page

### DIFF
--- a/00-instructors.md
+++ b/00-instructors.md
@@ -14,11 +14,6 @@ I'm a contributor to the Jupyter ecosystem. I am currently working on extension 
 I’m a longtime Jupyter user and contributor, maintainer of Gator and JupyterLab-LaTeX, with hands-on work across JupyterLab, JupyterHub, and the wider ecosystem. I built a JupyterHub-based platform serving 300+ NIH researchers; worked on numerous JupyterLab extensions and recently built a community JupyterLab Marketplace (https://labextensions.dev/).
 
 
-## Martha Cryan
-
-TODO: Bio
-
-
 ## Jason Grout
 
 TODO: Bio


### PR DESCRIPTION
Sadly, Martha won't be at JupyterCon :sob: We'll miss you!

We've credited your amazing prior work in the Anatomy module.



<!-- readthedocs-preview jupytercon2025-developingextensions start -->
---
:mag: Preview: https://jupytercon2025-developingextensions--56.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview jupytercon2025-developingextensions end -->