### PR TITLE
Improve consistency of titles displayed on website

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -1,7 +1,7 @@
 version: 1
 
 project:
-  title: "JupyterCon Workshop: Extension Development for Everyone!"
+  title: "Extension Development for Everyone!"
   # description:
   # keywords: []
   # authors: []
@@ -22,4 +22,4 @@ site:
     style: "assets/styles/style.css"
     # favicon: favicon.ico
     # logo: site_logo.png
-    logo_text: "JupyterLab Extension Development for Everyone!"
+    logo_text: "JupyterCon 2025: Extension Development for Everyone!"


### PR DESCRIPTION
Currently 3 different "titles" for the workshop show up on the landing page. This PR makes them a bit more consistent.

<img width="2196" height="462" alt="image" src="https://github.com/user-attachments/assets/1193288e-4cba-453e-9ff0-f925c8430914" />


<!-- readthedocs-preview jupytercon2025-developingextensions start -->
---
:mag: Preview: https://jupytercon2025-developingextensions--58.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview jupytercon2025-developingextensions end -->