### PR TITLE
Fix height calculation of document outline

### DIFF
--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -1,3 +1,7 @@
 body {
   font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
+
+[aria-label="Document Outline"] {
+  max-height: calc(100vh - 100px) !important;
+}


### PR DESCRIPTION
Currently, for pages with a long outline, the right side panel's contents overflow off the bottom of the screen (even when scrolled all the way down).

Unfortunately, there seems to be no id or unique class I can use to select this element, so I'm using the aria-label :grimacing:

See https://github.com/jupyter-book/myst-theme/pull/665