### PR TITLE
Fix broken term references

### DIFF
--- a/04-materials/01-exploring-extensions.md
+++ b/04-materials/01-exploring-extensions.md
@@ -26,8 +26,8 @@
 
 ## Extensions and plugins and widgets -- oh, my!
 
-While they sound similar, `extensions <extension>` and {term}`plugins <plugin>` serve
-different purposes.
+While they sound similar, {term}`extensions <extension>` and {term}`plugins <plugin>`
+serve different purposes.
 
 {term}`Plugins <plugin>` are JupyterLab's fundamental building blocks which define
 functionality and business logic.
@@ -78,8 +78,8 @@ Examples:
 ### {term}`Frontend extension`
 
 Extensions that run in the JupyterLab frontend (i.e. the user's browser), which means it
-can change anything about the appearance of JupyterLab and provide new {term}`widgets
-<widget>` for display and/or interactions.
+can change anything about the appearance of JupyterLab and provide new
+{term}`widgets <widget>` for display and/or interactions.
 
 Examples:
 

--- a/04-materials/02-anatomy-of-extensions.md
+++ b/04-materials/02-anatomy-of-extensions.md
@@ -1074,10 +1074,10 @@ resources of the JupyterLab server, for example to read data from disk.
 We know that server extensions provide HTTP endpoints that can be consumed by
 {term}`frontend extensions <frontend extension>`.
 
-We know how to provide JSON data from the server and consume it in a {term}`widget
-<widget>`.
+We know how to provide JSON data from the server and consume it in a
+{term}`widget <widget>`.
 
-We know how to dynamically update {term}`widget` HTML elements.
+We know how to dynamically update {term}`widget <widget>` HTML elements.
 
 
 ## 😖 The widget isn't interactive!


### PR DESCRIPTION
When roles span multiple lines, they don't render correctly :( Be careful when formatting text!

(Also, one time, I forgot to include the role name :laughing: woopsie)


I feel this qualifies as a bug in MyST! See: https://github.com/jupyter-book/mystmd/issues/2379

<!-- readthedocs-preview jupytercon2025-developingextensions start -->
---
:mag: Preview: https://jupytercon2025-developingextensions--69.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview jupytercon2025-developingextensions end -->