### PR TITLE
Pin Node.js requirement to 22 (LTS)

### DIFF
--- a/04-materials/02-anatomy-of-extensions.md
+++ b/04-materials/02-anatomy-of-extensions.md
@@ -75,7 +75,7 @@ micromamba activate jupytercon2025
 ## gh: The GitHub CLI
 ## copier: A tool for quickstarting an extension from a template
 ## jinja2-time: A dependency of the official JupyterLab extension template
-micromamba install python pip nodejs gh "copier~=9.2" jinja2-time
+micromamba install python pip nodejs=22 gh "copier~=9.2" jinja2-time
 ```
 
 


### PR DESCRIPTION
## Summary

This PR updates the Node.js version requirement from 18 to 22 throughout the workshop materials.

## Motivation

**Node.js 18 reached End-of-Life on April 30, 2025** and no longer receives security updates or maintenance releases. Continuing to use Node.js 18 exposes workshop participants to:
- Unpatched security vulnerabilities
- Lack of bug fixes
- Potential incompatibility with cloud platforms (AWS Lambda, Vercel, etc. are deprecating Node.js 18)

## Why Node.js 22?

Node.js 22 is the current **LTS (Long-Term Support)** version and the ideal choice for this workshop because:

✅ **Active LTS Support**: Maintained until **April 2027**
✅ **Production-Ready**: Stable and battle-tested
✅ **Verified Compatibility**: Works well with the JupyterLab extension template
✅ **Security**: Receives regular security patches and updates
✅ **Not Too Bleeding Edge**: Avoids potential incompatibilities from the latest versions (Node.js 23+)

## What Changed

- Updated `micromamba install` command to pin `nodejs=22`

## References

- [Node.js 18 EOL Announcement](https://nodejs.org/en/blog/release/v18.20.8)
- [Node.js Release Schedule](https://github.com/nodejs/release#release-schedule)
- [AWS Lambda Node.js 18 Deprecation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)
- [Vercel Node.js 18 Deprecation](https://vercel.com/changelog/node-js-18-is-being-deprecated)

## Testing

- Verified no remaining Node.js 18 references in documentation
- Confirmed Node.js 22 is compatible with JupyterLab extension development workflow

<!-- readthedocs-preview jupytercon2025-developingextensions start -->
---
:mag: Preview: https://jupytercon2025-developingextensions--70.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview jupytercon2025-developingextensions end -->