### PR TITLE
Downgrade errors about vscode link resolution -> warnings

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -11,6 +11,11 @@ project:
     - "_*"
     - "README.md"
 
+  error_rules:
+    - rule: "link-resolves"
+      key: "https://code.visualstudio.com/"
+      severity: "warn"
+
 
 site:
   template: "book-theme"


### PR DESCRIPTION


<!-- readthedocs-preview jupytercon2025-developingextensions start -->
---
:mag: Preview: https://jupytercon2025-developingextensions--86.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview jupytercon2025-developingextensions end -->