### PR TITLE
Fix capitalization of term reference

### DIFF
--- a/04-materials/01-exploring-extensions.md
+++ b/04-materials/01-exploring-extensions.md
@@ -139,7 +139,7 @@ Extensions that tell Jupyter how to view information in a specific file type
 ([MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types)).
 
 These are a special case of {term}`frontend extensions <frontend extension>` which map a
-{term}`widget` viewer with the supported file MIME type strings.
+{term}`widget <widget>` viewer with the supported file MIME type strings.
 
 
 #### Examples


### PR DESCRIPTION
This term displays as "Widget" because the term definition includes with a capital W. We can override that with this syntax. (See https://github.com/jupyter-book/mystmd/issues/2338 for details)

<!-- readthedocs-preview jupytercon2025-developingextensions start -->
---
:mag: Preview: https://jupytercon2025-developingextensions--87.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview jupytercon2025-developingextensions end -->