### PR TITLE
Update 02-anatomy-of-extensions.md

### DIFF
--- a/04-materials/02-anatomy-of-extensions.md
+++ b/04-materials/02-anatomy-of-extensions.md
@@ -593,8 +593,8 @@ Then, add the command palette as a dependency of our plugin:
 :filename: src/index.ts
 
 const plugin: JupyterFrontEndPlugin<void> = {
-  id: 'myextension:plugin',
-  description: 'A JupyterLab extension.',
+  id: 'jupytercon2025-extension-workshop:plugin',
+  description: 'A JupyterLab extension that displays a random image and caption.',
   autoStart: true,
   requires: [ICommandPalette],  // dependencies of our extension
   activate: (


### PR DESCRIPTION
Made the plugin's id and description congruous across code cells.

<!-- readthedocs-preview jupytercon2025-developingextensions start -->
---
:mag: Preview: https://jupytercon2025-developingextensions--102.org.readthedocs.build/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview jupytercon2025-developingextensions end -->